### PR TITLE
Elm it up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 node_js:
-- "0.10"
-- "0.11"
+- "4"
+- "6"
 sudo: false
 language: node_js
-script: "npm run test-cov"
+script: "npm run test:cov"
 after_script: "npm install coveralls@2 && cat ./coverage/lcov.info | coveralls"

--- a/index.js
+++ b/index.js
@@ -1,105 +1,209 @@
-// const debug = require('debug')('barracks')
-const isFsa = require('flux-standard-action').isFSA
-const series = require('run-series')
+const mutate = require('xtend/mutable')
 const assert = require('assert')
+const xtend = require('xtend')
 
 module.exports = dispatcher
 
 // initialize a new barracks instance
-// null -> obj
-function dispatcher () {
-  const actions = {}
+// obj -> obj
+function dispatcher (handlers) {
+  handlers = handlers || {}
+  assert.equal(typeof handlers, 'object', 'barracks: handlers should be undefined or an object')
 
-  emit._actions = actions
-  emit.emit = emit
-  emit.on = on
-  return emit
+  const onError = handlers.onError || defaultOnError
+  const onAction = handlers.onAction
+  const onState = handlers.onState
 
-  // register a new action
-  // (str, fn) -> obj
-  function on (action, cb) {
-    assert.equal(typeof action, 'string')
-    assert.equal(typeof cb, 'function')
+  assert.equal(typeof onError, 'function', 'barracks: onError should be a function')
+  assert.ok(!onAction || typeof onAction === 'function', 'barracks: onAction should be undefined or a function')
+  assert.ok(!onState || typeof onState === 'function', 'barracks: onState should be undefined or a function')
 
-    actions[action] = actions[action] ? actions[action] : []
-    assert.equal(actions[action].length, 0, 'only one callback per action')
-    actions[action].push(cb)
+  var reducersCalled = false
+  var effectsCalled = false
+  var stateCalled = false
+  var subsCalled = false
 
-    return emit
+  const subscriptions = start._subscriptions = {}
+  const reducers = start._reducers = {}
+  const effects = start._effects = {}
+  const models = start._models = []
+  var _state = {}
+
+  start.model = setModel
+  start.state = getState
+  start.start = start
+  return start
+
+  // push a model to be initiated
+  // obj -> null
+  function setModel (model) {
+    assert.equal(typeof model, 'object', 'barracks.store.model: model should be an object')
+    models.push(model)
   }
 
-  // call an action and
-  // execute the corresponding callback
-  // (str, obj?) -> prom
-  function emit (action, data) {
-    if (isFsa(action)) {
-      data = action
-      action = action.type
-    }
-    assert.ok(Array.isArray(actions[action]), 'action exists')
-    const fn = actions[action][0]
-    const stack = [action]
-
-    return fn(data, wait)
-
-    // internal 'wait()' function
-    // ([str], fn) -> prom
-    function wait (action, cb) {
-      action = Array.isArray(action) ? action : [action]
-      cb = cb || function () {}
-
-      // retrieve actions
-      const arr = action.map(function (name) {
-        const actExists = Array.isArray(actions[name])
-        assert.ok(actExists, 'action ' + name + ' does not exist')
-        const fn = actions[name][0]
-        return createDone(name, fn)
+  // get the current state from the store
+  // obj? -> obj
+  function getState (opts) {
+    opts = opts || {}
+    assert.equal(typeof opts, 'object', 'barracks.store.state: opts should be an object')
+    if (opts.state) {
+      const initialState = {}
+      const nsState = {}
+      models.forEach(function (model) {
+        const ns = model.namespace
+        if (ns) {
+          nsState[ns] = {}
+          apply(ns, model.state, nsState)
+          nsState[ns] = xtend(nsState[ns], opts.state[ns])
+        } else {
+          apply(model.namespace, model.state, initialState)
+        }
       })
+      return xtend(_state, xtend(opts.state, nsState))
+    } else if (opts.noFreeze) {
+      return xtend(_state)
+    } else {
+      return Object.freeze(xtend(_state))
+    }
+  }
 
-      return series(arr, cb)
+  // initialize the store handlers, get the send() function
+  // obj? -> fn
+  function start (opts) {
+    opts = opts || {}
+    assert.equal(typeof opts, 'object', 'barracks.store.start: opts should be undefined or an object')
 
-      // wrap an action with a `done()` method
-      // for usage in `series()`
-      // (str, fn(any, (str, fn)) -> fn
-      function createDone (name, fn) {
-        return function (done) {
-          const index = stack.indexOf(name)
-          if (index !== -1) return emitErr('circular dependency detected')
-          stack.push(name)
+    // register values from the models
+    models.forEach(function (model) {
+      const ns = model.namespace
+      if (!stateCalled && model.state && !opts.noState) {
+        apply(ns, model.state, _state)
+      }
+      if (!reducersCalled && model.reducers && !opts.noReducers) {
+        apply(ns, model.reducers, reducers)
+      }
+      if (!effectsCalled && model.effects && !opts.noEffects) {
+        apply(ns, model.effects, effects)
+      }
+      if (!subsCalled && model.subscriptions && !opts.noSubscriptions) {
+        apply(ns, model.subscriptions, subscriptions, createSend, onError)
+      }
+    })
 
-          if (fn.length === 2) return fn(data, retFn)
-          else {
-            fn(data)
-            stack.pop()
-            done()
-          }
+    if (!opts.noState) stateCalled = true
+    if (!opts.noReducers) reducersCalled = true
+    if (!opts.noEffects) effectsCalled = true
+    if (!opts.noSubs) subsCalled = true
 
-          // execute `wait()` and `done()`
-          // to both delegate new `series()` calls
-          // handle cb's, and exit once done
-          // (str, fn) -> null
-          function retFn (action, cb) {
-            cb = cb || function () {}
-            if (action) return wait(action, endWrap)
-            endWrap()
+    return createSend
 
-            function endWrap () {
-              cb()
-              stack.pop()
-              done()
-            }
+    // call an action from a view
+    // (str, bool?) -> (str, any?, fn?) -> null
+    function createSend (selfName, callOnError) {
+      assert.equal(typeof selfName, 'string', 'barracks.store.start.createSend: selfName should be a string')
+      assert.ok(!callOnError || typeof callOnError === 'boolean', 'barracks.store.start.send: callOnError should be undefined or a boolean')
+
+      return function send (name, data, cb) {
+        if (!cb && !callOnError) {
+          cb = data
+          data = null
+        }
+        data = (typeof data === 'undefined' ? null : data)
+
+        assert.equal(typeof name, 'string', 'barracks.store.start.send: name should be a string')
+        assert.ok(!cb || typeof cb === 'function', 'barracks.store.start.send: cb should be a function')
+
+        const done = callOnError ? onErrorCallback : cb
+        _send(name, data, selfName, done)
+
+        function onErrorCallback (err) {
+          err = err || null
+          if (err) {
+            onError(err, _state, function createSend (selfName) {
+              return function send (name, data) {
+                assert.equal(typeof name, 'string', 'barracks.store.start.send: name should be a string')
+                data = (typeof data === 'undefined' ? null : data)
+                _send(name, data, selfName, done)
+              }
+            })
           }
         }
       }
     }
 
-    // emit an error
-    // any -> null
-    function emitErr (err) {
-      if (!actions.error) {
-        throw new Error("unhandled 'error' event")
-      }
-      actions.error[0](err)
+    // call an action
+    // (str, str, any, fn) -> null
+    function _send (name, data, caller, cb) {
+      assert.equal(typeof name, 'string', 'barracks._send: name should be a string')
+      assert.equal(typeof caller, 'string', 'barracks._send: caller should be a string')
+      assert.equal(typeof cb, 'function', 'barracks._send: cb should be a function')
+
+      process.nextTick(function () {
+        var reducersCalled = false
+        var effectsCalled = false
+        const newState = xtend(_state)
+
+        if (onAction) onAction(data, _state, name, caller, createSend)
+
+        // validate if a namespace exists. Namespaces are delimited by ':'.
+        var actionName = name
+        if (/:/.test(name)) {
+          const arr = name.split(':')
+          var ns = arr.shift()
+          actionName = arr.join(':')
+        }
+
+        const _reducers = ns ? reducers[ns] : reducers
+        if (_reducers && _reducers[actionName]) {
+          if (ns) {
+            const reducedState = _reducers[actionName](data, _state[ns])
+            mutate(newState[ns], xtend(_state[ns], reducedState))
+          } else {
+            mutate(newState, reducers[actionName](data, _state))
+          }
+          reducersCalled = true
+          if (onState) onState(data, newState, _state, actionName, createSend)
+          _state = newState
+          cb()
+        }
+
+        const _effects = ns ? effects[ns] : effects
+        if (!reducersCalled && _effects && _effects[actionName]) {
+          const send = createSend('effect: ' + name)
+          if (ns) _effects[actionName](data, _state[ns], send, cb)
+          else _effects[actionName](data, _state, send, cb)
+          effectsCalled = true
+        }
+
+        if (!reducersCalled && !effectsCalled) {
+          throw new Error('Could not find action ' + actionName)
+        }
+      })
     }
   }
+}
+
+// compose an object conditionally
+// optionally contains a namespace
+// which is used to nest properties.
+// (str, obj, obj, fn?) -> null
+function apply (ns, source, target, createSend, done) {
+  Object.keys(source).forEach(function (key) {
+    if (ns) {
+      if (!target[ns]) target[ns] = {}
+      target[ns][key] = source[key]
+    } else {
+      target[key] = source[key]
+    }
+    if (createSend && done) {
+      const send = createSend('subscription: ' + ns ? ns + ':' + key : key)
+      source[key](send, done)
+    }
+  })
+}
+
+// handle errors all the way at the top of the trace
+// err? -> null
+function defaultOnError (err) {
+  throw err
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "standard && NODE_ENV=test node test",
-    "test-cov": "standard && NODE_ENV=test istanbul cover test.js",
+    "test:cov": "standard && NODE_ENV=test istanbul cover test.js",
     "watch": "watch 'npm t'"
   },
   "repository": "yoshuawuyts/barracks",
@@ -21,16 +21,23 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "bundle-collapser": "^1.2.1",
     "coveralls": "~2.10.0",
+    "es2020": "^1.1.6",
     "istanbul": "~0.2.10",
+    "noop2": "^2.0.0",
     "standard": "^7.1.2",
     "tape": "^3.0.3",
+    "uglifyify": "^3.0.2",
+    "unassertify": "^2.0.3",
     "watch": "^0.16.0"
   },
   "dependencies": {
     "debug": "^2.0.0",
     "flux-standard-action": "^0.6.0",
-    "run-series": "^1.1.2"
+    "noop2": "^2.0.0",
+    "run-series": "^1.1.2",
+    "xtend": "^4.0.1"
   },
   "files": [
     "LICENSE",

--- a/script/test-size
+++ b/script/test-size
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+usage () {
+cat << USAGE
+script/test-size
+  Commands:
+    g, gzip (default)    Output gzip size
+    m, minified          Output size minified
+    d, discify           Run discify
+USAGE
+}
+
+gzip_size () {
+  browserify index.js \
+    -g unassertify \
+    -g es2020 \
+    -g uglifyify \
+    -p bundle-collapser/plugin \
+    | uglifyjs \
+    | gzip-size \
+    | pretty-bytes
+}
+
+min_size () {
+  browserify index.js \
+    -g unassertify \
+    -g es2020 \
+    -g uglifyify \
+    -p bundle-collapser/plugin \
+    | uglifyjs \
+    | wc -c \
+    | pretty-bytes
+}
+
+run_discify () {
+  browserify index.js --full-paths \
+    -g unassertify \
+    -g es2020 \
+    -g uglifyify \
+    | uglifyjs \
+    | discify --open
+}
+
+# set CLI flags
+getopt -T > /dev/null
+if [ "$?" -eq 4 ]; then
+  args="$(getopt --long help discify minified --options hmdg -- "$*")"
+else args="$(getopt h "$*")"; fi
+[ ! $? -eq 0 ] && { usage && exit 2; }
+eval set -- "$args"
+
+# parse CLI flags
+while true; do
+  case "$1" in
+    -h|--help) usage && exit 1 ;;
+    -- ) shift; break ;;
+    * ) break ;;
+  esac
+done
+
+case "$1" in
+  d|discify) shift; run_discify "$@" ;;
+  m|minified) shift; printf "min:  %s\n" "$(min_size)" "$@" ;;
+  g|gzip|*) shift; printf "gzip: %s\n" "$(gzip_size)" "$@" ;;
+esac


### PR DESCRIPTION
This is pretty much a complete rewrite of `barracks`, catered for [choo](https://github.com/yoshuawuyts/choo); it now has a better split out architecture that caters to all forms of async problems. In essence it's quite similar to `choo@2`; but adds composition for `effects` (as per https://github.com/yoshuawuyts/choo/issues/34).

There's also a notion of `handlers` that can react to state changes, errors and actions (as per https://github.com/yoshuawuyts/choo/issues/15). This API is slightly awkward I've found that each handler is slightly different; but I reckon they're good enough. The only point of debate would be whether or not to make the `caller` argument an array to display the full stack trace; and to add the `caller` to the `onError` handler. The latter adding a reasonable source of complexity for information that's available already despite in a shittier format. Input here would be heaps valued.

Also we're not 100% test covered (sitting closer to 70%); but I've run this off every example in `choo` and it seems to work soooo :sparkles:

I'd suggest reading the README.md file for a full overview of the new API. Thanks!