### PR TITLE
index: nextTick -> setTimeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ function dispatcher (handlers) {
       assert.equal(typeof caller, 'string', 'barracks._send: caller should be a string')
       assert.equal(typeof cb, 'function', 'barracks._send: cb should be a function')
 
-      process.nextTick(function () {
+      setTimeout(function () {
         var reducersCalled = false
         var effectsCalled = false
         const newState = xtend(_state)
@@ -178,7 +178,7 @@ function dispatcher (handlers) {
         if (!reducersCalled && !effectsCalled) {
           throw new Error('Could not find action ' + actionName)
         }
-      })
+      }, 0)
     }
   }
 }

--- a/test.js
+++ b/test.js
@@ -201,7 +201,7 @@ tape('handlers: reducers', (t) => {
     send('foo', { foo: 'baz' })
     send('sup', 'nope')
     send('meow:woof')
-    process.nextTick(function () {
+    setTimeout(function () {
       const state = store.state()
       const expected = {
         foo: 'baz',
@@ -209,7 +209,7 @@ tape('handlers: reducers', (t) => {
         meow: { beep: 'boop' }
       }
       t.deepEqual(state, expected, 'state was updated')
-    })
+    }, 10)
   })
 })
 
@@ -250,13 +250,11 @@ tape('handlers: effects', (t) => {
     send('foo', { beep: 'woof' })
     send('meow:woof')
 
-    process.nextTick(function () {
-      process.nextTick(function () {
-        const state = store.state()
-        const expected = { bin: 'baz', beep: 'woof' }
-        t.deepEqual(state, expected, 'state was updated')
-      })
-    })
+    setTimeout(function () {
+      const state = store.state()
+      const expected = { bin: 'baz', beep: 'woof' }
+      t.deepEqual(state, expected, 'state was updated')
+    }, 10)
   })
 
   t.test('should be able to nest effects and return data', (t) => {


### PR DESCRIPTION
Replaces `process.nextTick` with `setTimeout` as [under the hood](https://github.com/defunctzombie/node-process/blob/master/browser.js#L82) browserify calls that any way; and for our use case it doesn't quite matter which one we use - all we care about is that it doesn't happen synchronously :sparkles: