### PR TITLE
Docs: send() includes done param

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,7 @@ app.model({
             error: err
           }))
         } else {
-          send('moreFoo', { count: foo.count })
-          done()
+          send('moreFoo', { count: foo.count }, done)
         }
       })
     }
@@ -250,7 +249,7 @@ app.model({
   subscriptions: {
     emitWoofs: (send, done) => {
       // emit a woof every second
-      setInterval(() =>  send('print', { woof: 'meow?' }), 1000)
+      setInterval(() =>  send('print', { woof: 'meow?' }, done), 1000)
     }
   },
   effects: {


### PR DESCRIPTION
Seems like `send()` calls an error when it doesn't include the `done` param.