### PR TITLE
docs: clarify use of second start

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ store.model({
 const createSend = store.start({ noSubscriptions: true })
 const send = createSend('myDispatcher', true)
 document.addEventListener('DOMContentLoaded', () => {
-  store.start()
+  store.start() // fire up subscriptions
   const state = store.state()
   send('foo:start', { name: 'Loki' })
 })
@@ -104,6 +104,11 @@ Start the store and get a `createSend(name)` function. Pass a unique `name` to
   starting the application. Useful when only wanting the initial `state`
 - __reducers:__ default: true. Set to false to not register `reducers` when
   starting the application. Useful when only wanting the initial `state`
+
+If the store has disabled any of the handlers (e.g. `{ reducers: false }`),
+calling `store.start()` a second time will register the remaining values. This
+is a useful if not everything can be started at the same time (e.g. have
+`subscriptions` wait for the `DOMContentLoaded` event).
 
 ### send(name, data?)
 Send a new action to the models with optional data attached. Namespaced models


### PR DESCRIPTION
Clarifies usage of the second `start()` call; supersedes #36. Thanks!

cc/ @timwis 