### PR TITLE
onAction: fix sub prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -196,7 +196,7 @@ function apply (ns, source, target, createSend, done) {
       target[key] = source[key]
     }
     if (createSend && done) {
-      const send = createSend('subscription: ' + ns ? ns + ':' + key : key)
+      const send = createSend('subscription: ' + (ns ? ns + ':' + key : key))
       source[key](send, done)
     }
   })


### PR DESCRIPTION
Ternary statement was broken. Should fix the naming of subscriptions, rather than putting out `undefined`. Thanks! cc/ @timwis 