### PR TITLE
onErrorWrap should pass all params. Fixes yoshuawuyts/choo#142

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,7 +210,7 @@ function defaultOnError (err) {
 }
 
 function wrapOnError (onError) {
-  return function onErrorWrap (err) {
-    if (err) onError(err)
+  return function onErrorWrap (err, state, createSend) {
+    if (err) onError(err, state, createSend)
   }
 }


### PR DESCRIPTION
@mw222rs can you see if this resolves the issue for you as well?

Here's a quick way to test if it's helpful:
```bash
git clone -b fix-on-error-wrap-params https://github.com/timwis/barracks.git
```
Then from within your application directory:
```bash
npm link ../path/to/cloned/barracks
```