### PR TITLE
Fix example to do with subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ store.model({
   subscriptions: {}
 })
 
-const createSend = store.start({ subscriptions: true })
+// Don't fire subscriptions yet
+const createSend = store.start({ subscriptions: false })
 const send = createSend('myDispatcher', true)
 document.addEventListener('DOMContentLoaded', () => {
   store.start() // fire up subscriptions


### PR DESCRIPTION
Seems to me as if the example with another call to store.start is for delayed subscription triggering, although it won't work that way since the `subscriptions` option is true, causing subscriptions to be triggered in the first call to `store.start`.

Therefore I propose the change to configure `subscriptions` as false in the first call to `store.start`.