### PR TITLE
Merge noSubscriptions and subscriptions options

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,7 +160,7 @@ function dispatcher (hooks) {
       _state = wrapHook(_state, initialStateWraps)
     }
 
-    if (!opts.noSubscriptions) subsCalled = true
+    if (opts.subscriptions !== false) subsCalled = true
     if (!opts.noReducers) reducersCalled = true
     if (!opts.noEffects) effectsCalled = true
     if (!opts.noState) stateCalled = true

--- a/test.js
+++ b/test.js
@@ -137,6 +137,17 @@ tape('api: createSend = store.start(opts)', (t) => {
     const subscriptions = Object.keys(store._subscriptions)
     t.deepEqual(subscriptions.length, 0, 'no subscriptions registered')
   })
+
+  t.test('opts.subscriptions = true should register subs after initial call with subs disabled',
+  (t) => {
+    t.plan(1)
+    const store = barracks()
+    store.model({ subscriptions: { foo: noop } })
+    store.start({ subscriptions: false })
+    store.start()
+    const subscriptions = Object.keys(store._subscriptions)
+    t.deepEqual(subscriptions.length, 1, 'subscriptions registered')
+  })
 })
 
 tape('api: state = store.state()', (t) => {


### PR DESCRIPTION
The `noSubscriptions` option really overlaps with `subscriptions` option and should be merged with the latter AFAICT. Includes a corresponding test.